### PR TITLE
Unicode renderer tweak

### DIFF
--- a/src/main/java/ch/astorm/jchess/util/UnicodePositionRenderer.java
+++ b/src/main/java/ch/astorm/jchess/util/UnicodePositionRenderer.java
@@ -49,7 +49,7 @@ public class UnicodePositionRenderer extends AbstractTextPositionRenderer {
             sb.append(super.getLineSeparator());
             if (i>0) sb.append(super.getLineSeparator());
         }
-        sb.append("\ta\tb\tc\td\te\tf\tg\th");
+        sb.append(" \ta\tb\tc\td\te\tf\tg\th");
         return sb;
     }
 

--- a/src/test/java/ch/astorm/jchess/util/UnicodePositionRendererTest.java
+++ b/src/test/java/ch/astorm/jchess/util/UnicodePositionRendererTest.java
@@ -21,7 +21,7 @@ public class UnicodePositionRendererTest {
             "3\t \t \t \t \t \t \t \t \t" + separator + separator +
             "2\t♙\t♙\t♙\t♙\t♙\t♙\t♙\t♙\t" + separator + separator +
             "1\t♖\t♘\t♗\t♕\t♔\t♗\t♘\t♖\t" + separator +
-            "\ta\tb\tc\td\te\tf\tg\th" + separator;
+            " \ta\tb\tc\td\te\tf\tg\th" + separator;
 
     @Test
     public void testUnicodeRendering() {


### PR DESCRIPTION
tab horizontal spacing varies depending on where is displayed.

In cases where a single tab doesn't make a good job to preserve the square shape of the board you could try to replace tabs for a number of spaces...

However, the last line in the board is the only line that doesn't have a space before the tab at the beginning of the line.

This simple tweak will allow replacing tabs to be more effective. 